### PR TITLE
Feat/os

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
     executor: ci-container
     steps:
       - checkout
-      - run: cmake . -D NETERO_AUDIO=OFF -DNETERO_GRAPHICS=OFF -D CODE_COVERAGE=ON
+      - run: cmake . -D NETERO_AUDIO=OFF -DNETERO_GRAPHICS=OFF -D MOCK_INTERFACES=ON -D CODE_COVERAGE=ON
       - run: make
       - run: make test
       - run: lcov --capture --directory . --output-file coverage.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ OPTION(NETERO_GRAPHICS "Graphics component based on ecs submodule" ON)
 ## Build config
 OPTION(WIN32_STATIC "Link staticaly with win32's dll" OFF)
 OPTION(CODE_COVERAGE "Enable coverage reporting" OFF)
+OPTION(MOCK_INTERFACES "Enable mock interfaces" OFF)
 
 set(INCLUDE_DIRECTORY_PATH ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set(HEADERS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/netero)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Containers:
  * shared_buffer: thread safe circular buffer
  * set: std::set with isSubsetOf and interWith feature
  * type_id: static type typeId container (needed for the ecs)
- * os: namespace containing OS getter helper, like userlogin, home dir path...
+ * os: namespace containing OS helper, like userlogin, home dir path...
 
 The core contain an Observer pattern, with the following container:
  * slot: a callback holder container

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Containers:
  * shared_buffer: thread safe circular buffer
  * set: std::set with isSubsetOf and interWith feature
  * type_id: static type typeId container (needed for the ecs)
+ * os: namespace containing OS getter helper, like userlogin, home dir path...
 
 The core contain an Observer pattern, with the following container:
  * slot: a callback holder container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       rm -rf /opt/netero/build
       && mkdir /opt/netero/build
       && cd /opt/netero/build
-      && cmake .. -D NETERO_AUDIO=OFF -D NETERO_GRAPHICS=OFF -D CODE_COVERAGE=ON
+      && cmake .. -D NETERO_AUDIO=OFF -D NETERO_GRAPHICS=OFF -D MOCK_INTERFACES=ON -D CODE_COVERAGE=ON
       && make
       && make test
       && lcov --capture --directory . --output-file coverage.info

--- a/include/netero/os.hpp
+++ b/include/netero/os.hpp
@@ -6,7 +6,8 @@
 #pragma once
 
 /**
- * @brief 
+ * @file os.hpp
+ * @brief Operating System ressources lock and standard path getters.
  */
 
 #include <string>

--- a/include/netero/os.hpp
+++ b/include/netero/os.hpp
@@ -1,0 +1,65 @@
+/**
+ * Netero sources under BSD-3-Clause
+ * see LICENSE.txt
+ */
+
+#pragma once
+
+/**
+ * @brief 
+ */
+
+#include <string>
+
+/**
+ * Namespace related to os specific resources.
+ */
+namespace netero::os {
+
+	/**
+	 * @brief Get the logged user's username.
+	 * @return A string containing the username of logged user.
+	 */
+    std::string   getSessionUsername();
+
+	/**
+	 * @brief Get the user's home directory path.
+	 */
+	std::string	getUserHomeDirectoryPath();
+
+	/**
+	 * @brief Get the user's app data path.
+	 * This is the directory you are likely to create a folder
+	 * with the name of your application and store config files.
+	 */
+	std::string getUserAppDataRoamingPath();
+	
+	/**
+	 * @brief Perform necessary init call if needed
+	 * This help you while you are using netero beside
+	 * other libraries that may require access to the COM
+	 * interface on windows for example.
+	 * For example on windows Netero will try to init the COM
+	 * library, if it can not it will simply conform to the current
+	 * initialization. This is used by the audio submodule.
+	 */
+    void    acquireSystemResources();
+
+	/**
+	 * @brief Release the OS handle if necessary
+	 */
+    void    releaseSystemResources();
+
+	/**
+	 * @brief Return the number of locks, might be non zero, netero submodule
+	 * may use this function set to access COM interfaces for example.
+	 */
+    int     getSystemResourcesLocks();
+
+	/**
+	 * @brief Tell you if Netero have preform initialization.
+	 */
+    bool    isSystemLibraryHolder();
+	
+}
+

--- a/modules/audio/backends/Wasapi/WASAPI.cpp
+++ b/modules/audio/backends/Wasapi/WASAPI.cpp
@@ -3,6 +3,7 @@
  * see LICENSE.txt
  */
 
+#include <netero/os.hpp>
 #include "WASAPI.hpp"
 
 // ----------------------------------------
@@ -21,13 +22,15 @@ const IID IID_IAudioSessionControl = __uuidof(IAudioSessionControl);
 // ----------------------------------
 
 netero::audio::backend::impl::impl() {
-	HRESULT	result;
+
+	netero::os::acquireSystemResources();
+	
 	// Initialize COM library in the current thread
-	result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
-	test_result(result);
+	//result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+	//test_result(result);
 
 	// Create COM device enumerator object
-	result = CoCreateInstance(CLSID_MMDeviceEnumerator,
+	HRESULT result = CoCreateInstance(CLSID_MMDeviceEnumerator,
 		nullptr,
 		CLSCTX_ALL,
 		IID_IMMDeviceEnumerator,
@@ -36,7 +39,8 @@ netero::audio::backend::impl::impl() {
 }
 
 netero::audio::backend::impl::~impl() {
-	CoUninitialize();
+	netero::os::releaseSystemResources();
+	//CoUninitialize();
 }
 
 // -------------------------------------------

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -6,6 +6,7 @@ project(netero_core
 
 message(STATUS "Configure Netero libs")
 
+
 ##====================================
 ##  Core Sources
 ##====================================
@@ -49,6 +50,24 @@ list(APPEND PUBLIC_HEADER
         ${HEADERS_DIRECTORY}/observer/slot.hpp)
 
 ##====================================
+##  Os sources
+##====================================
+list(APPEND PUBLIC_HEADER
+        ${HEADERS_DIRECTORY}/os.hpp)
+if(MOCK_INTERFACES)
+    list(APPEND SRCS
+        os/mockOsHelpers.cpp)
+else()
+    if(WIN32)
+        list(APPEND SRCS
+            os/windowsOsHelpers.cpp)
+        list(APPEND LINK_LIBRARIES
+            Userenv)
+    endif(WIN32)
+endif(MOCK_INTERFACES)
+
+
+##====================================
 ##  Targets
 ##====================================
 
@@ -63,6 +82,11 @@ target_include_directories(netero
             $<INSTALL_INTERFACE:include>
             $<BUILD_INTERFACE:${INCLUDE_DIRECTORY_PATH}>
 )
+target_link_libraries(netero ${LINK_LIBRARIES})
+if(WIN32 AND WIN32_STATIC)
+    set_property(TARGET netero PROPERTY
+        MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Release>:Release>")
+endif()
 
 target_compile_features(netero PUBLIC cxx_std_17)
 

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -64,6 +64,14 @@ else()
         list(APPEND LINK_LIBRARIES
             Userenv)
     endif(WIN32)
+    if(APPLE)
+        list(APPEND SRCS
+                os/macOsHelpers.cpp)
+    endif(APPLE)
+    if(UNIX AND NOT APPLE)
+        list(APPEND SRCS
+                os/mockOsHelpers.cpp)
+    endif(UNIX AND NOT APPLE)
 endif(MOCK_INTERFACES)
 
 

--- a/modules/core/CMakeLists.txt
+++ b/modules/core/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
     endif(APPLE)
     if(UNIX AND NOT APPLE)
         list(APPEND SRCS
-                os/mockOsHelpers.cpp)
+                os/unixOsHelpers.cpp)
     endif(UNIX AND NOT APPLE)
 endif(MOCK_INTERFACES)
 

--- a/modules/core/os/macOsHelpers.cpp
+++ b/modules/core/os/macOsHelpers.cpp
@@ -1,0 +1,60 @@
+/**
+ * Netero sources under BSD-3-Clause
+ * see LICENSE.txt
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <uuid/uuid.h>
+#include <mutex>
+#include <atomic>
+#include <netero/os.hpp>
+
+std::string netero::os::getSessionUsername() {
+	uid_t uid = getuid();
+	struct passwd *userInfo = getpwuid(uid);
+	if (userInfo) {
+		return std::string(userInfo->pw_name);
+	}
+	return std::string();
+}
+
+std::string netero::os::getUserHomeDirectoryPath() {
+	uid_t uid = getuid();
+	struct passwd *userInfo = getpwuid(uid);
+	if (userInfo) {
+		return std::string(userInfo->pw_dir);
+	}
+	return std::string();
+}
+
+std::string netero::os::getUserAppDataRoamingPath() {
+	uid_t uid = getuid();
+	struct passwd *userInfo = getpwuid(uid);
+	if (userInfo) {
+		return std::string(userInfo->pw_dir) + "/Library";
+	}
+	return std::string();
+}
+
+static std::atomic<int>     g_com_library_locks = 0;
+static std::mutex           g_com_lock_mutex;
+
+void netero::os::acquireSystemResources() {
+	g_com_library_locks += 1;
+}
+
+void netero::os::releaseSystemResources() {
+	if (g_com_library_locks.load(std::memory_order_acquire) > 0) {
+		g_com_library_locks -= 1;
+	}
+}
+
+int netero::os::getSystemResourcesLocks() {
+	return g_com_library_locks.load(std::memory_order_acquire);
+}
+
+bool netero::os::isSystemLibraryHolder() {
+	return false;
+}

--- a/modules/core/os/mockOsHelpers.cpp
+++ b/modules/core/os/mockOsHelpers.cpp
@@ -1,0 +1,41 @@
+/**
+ * Netero sources under BSD-3-Clause
+ * see LICENSE.txt
+ */
+
+#include <mutex>
+#include <atomic>
+#include <netero/os.hpp>
+
+std::string netero::os::getSessionUsername() {
+	return std::string("Netero");
+}
+
+std::string netero::os::getUserHomeDirectoryPath() {
+	return std::string("/home/netero");
+}
+
+std::string netero::os::getUserAppDataRoamingPath() {
+	return std::string("/home/netero/.appData");
+}
+
+static std::atomic<int>     g_com_library_locks = 0;
+static std::mutex           g_com_lock_mutex;
+
+void netero::os::acquireSystemResources() {
+	g_com_library_locks += 1;
+}
+
+void netero::os::releaseSystemResources() {
+	if (g_com_library_locks.load(std::memory_order_acquire) > 0) {
+		g_com_library_locks -= 1;
+	}
+}
+
+int netero::os::getSystemResourcesLocks() {
+	return g_com_library_locks.load(std::memory_order_acquire);
+}
+
+bool netero::os::isSystemLibraryHolder() {
+	return false;
+}

--- a/modules/core/os/unixOsHelpers.cpp
+++ b/modules/core/os/unixOsHelpers.cpp
@@ -1,0 +1,60 @@
+/**
+ * Netero sources under BSD-3-Clause
+ * see LICENSE.txt
+ */
+
+#include <unistd.h>
+#include <sys/types.h>
+#include <pwd.h>
+#include <uuid/uuid.h>
+#include <mutex>
+#include <atomic>
+#include <netero/os.hpp>
+
+std::string netero::os::getSessionUsername() {
+	uid_t uid = getuid();
+	struct passwd *userInfo = getpwuid(uid);
+	if (userInfo) {
+		return std::string(userInfo->pw_name);
+	}
+	return std::string();
+}
+
+std::string netero::os::getUserHomeDirectoryPath() {
+	uid_t uid = getuid();
+	struct passwd *userInfo = getpwuid(uid);
+	if (userInfo) {
+		return std::string(userInfo->pw_dir);
+	}
+	return std::string();
+}
+
+std::string netero::os::getUserAppDataRoamingPath() {
+	uid_t uid = getuid();
+	struct passwd *userInfo = getpwuid(uid);
+	if (userInfo) {
+		return std::string(userInfo->pw_dir);
+	}
+	return std::string();
+}
+
+static std::atomic<int>     g_com_library_locks = 0;
+static std::mutex           g_com_lock_mutex;
+
+void netero::os::acquireSystemResources() {
+	g_com_library_locks += 1;
+}
+
+void netero::os::releaseSystemResources() {
+	if (g_com_library_locks.load(std::memory_order_acquire) > 0) {
+		g_com_library_locks -= 1;
+	}
+}
+
+int netero::os::getSystemResourcesLocks() {
+	return g_com_library_locks.load(std::memory_order_acquire);
+}
+
+bool netero::os::isSystemLibraryHolder() {
+	return false;
+}

--- a/modules/core/os/unixOsHelpers.cpp
+++ b/modules/core/os/unixOsHelpers.cpp
@@ -6,7 +6,6 @@
 #include <unistd.h>
 #include <sys/types.h>
 #include <pwd.h>
-#include <uuid/uuid.h>
 #include <mutex>
 #include <atomic>
 #include <netero/os.hpp>

--- a/modules/core/os/windowsOsHelpers.cpp
+++ b/modules/core/os/windowsOsHelpers.cpp
@@ -1,0 +1,101 @@
+/**
+ * Netero sources under BSD-3-Clause
+ * see LICENSE.txt
+ */
+
+#include <windows.h>
+#include <UserEnv.h>
+#include <shlobj_core.h>
+#include <combaseapi.h>
+#include <Lmcons.h>
+#include <mutex>
+#include <atomic>
+#include <netero/os.hpp>
+
+std::string netero::os::getSessionUsername() {
+    char    username[UNLEN + 1];
+    DWORD   len = UNLEN + 1;
+
+    if (GetUserName(username, &len)) {
+        return std::string(username);
+    }
+    return std::string();
+}
+
+std::string netero::os::getUserHomeDirectoryPath() {
+	char    path[32];
+	DWORD   len = 32;
+
+	if (GetProfilesDirectoryA(path, &len)) {
+		return std::string(path) + "\\" + netero::os::getSessionUsername();
+	}
+    return std::string();
+}
+
+std::string netero::os::getUserAppDataRoamingPath() {
+	PWSTR	str;
+
+	const HRESULT result = SHGetKnownFolderPath(FOLDERID_RoamingAppData,
+		0,
+		nullptr,
+		&str);
+	if (FAILED(result)) {
+		return std::string();
+	}
+	std::string string;
+	size_t converted_char = 0;
+	size_t size = wcslen(str);
+	size *= 2;
+
+	if (!str) {
+		return string;
+	}
+	auto c_string = new (std::nothrow) char[size];
+	if (!c_string) {
+		return string;
+	}
+	wcstombs_s(&converted_char, c_string, size, str, _TRUNCATE);
+	string = c_string;
+	delete[] c_string;
+	return string;
+}
+
+
+static std::atomic<int>     g_com_library_locks = 0;
+static std::mutex           g_com_lock_mutex;
+static std::atomic<bool>    g_is_com_holder = false;
+
+void netero::os::acquireSystemResources() {
+	if (g_com_library_locks.load(std::memory_order_acquire) == 0) {
+		std::scoped_lock<std::mutex>    lock(g_com_lock_mutex);
+		const HRESULT result = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+		if (result == S_OK) {
+            g_is_com_holder = true;
+		}
+        g_com_library_locks += 1;
+	}
+	else {
+        g_com_library_locks += 1;
+    }
+}
+
+void netero::os::releaseSystemResources() {
+	if (g_com_library_locks.load(std::memory_order_acquire) > 0) {
+		g_com_library_locks -= 1;
+		if (g_is_com_holder.load(std::memory_order_acquire) == true
+			&& g_com_library_locks.load(std::memory_order_acquire) == 0) {
+			std::scoped_lock<std::mutex>    lock(g_com_lock_mutex);
+			CoUninitialize();
+			g_is_com_holder = false;
+		}
+	}
+}
+
+int netero::os::getSystemResourcesLocks() {
+	return g_com_library_locks.load(std::memory_order_acquire);
+}
+
+bool netero::os::isSystemLibraryHolder() {
+	return g_is_com_holder.load(std::memory_order_acquire);
+}
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ endmacro(add_project_test)
 ##  Test Core
 ##====================================
 
+add_project_test(NAME test_os SOURCES test_os.cpp DEPENDS netero)
 add_project_test(NAME test_core_type_id SOURCES core/test_core_type_id.cpp)
 add_project_test(NAME test_avl SOURCES test_avl.cpp)
 add_project_test(NAME test_set SOURCES test_set.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,10 +54,10 @@ add_project_test(NAME bug_size_buffer SOURCES bug_size_buffer.cpp)
 ##====================================
 
 if (NETERO_AUDIO)
-    add_project_test(NAME test_audio_format SOURCES audio/test_audio_format.cpp DEPENDS netero_audio)
-    add_project_test(NAME example_audio_render SOURCES audio/example_audio_render.cpp DEPENDS netero_audio)
-    add_project_test(NAME example_audio_recorde SOURCES audio/example_audio_recorde.cpp DEPENDS netero_audio)
-    add_project_test(NAME example_audio_recorde_silence SOURCES audio/example_audio_recorde_silence.cpp DEPENDS netero_audio)
+    add_project_test(NAME test_audio_format SOURCES audio/test_audio_format.cpp DEPENDS netero netero_audio)
+    add_project_test(NAME example_audio_render SOURCES audio/example_audio_render.cpp DEPENDS netero netero_audio)
+    add_project_test(NAME example_audio_recorde SOURCES audio/example_audio_recorde.cpp DEPENDS netero netero_audio)
+    add_project_test(NAME example_audio_recorde_silence SOURCES audio/example_audio_recorde_silence.cpp DEPENDS netero netero_audio)
 endif(NETERO_AUDIO)
 
 ##====================================

--- a/tests/audio/example_audio_render.cpp
+++ b/tests/audio/example_audio_render.cpp
@@ -26,9 +26,9 @@ int main() {
         netero::audio::DeviceManager::getInstance().deviceDisconnectedSig.connect(&deviceDisconnectionSlot);
 
     	// Create 3 audio entities, which are sinusoid signal
-        auto* noteDo = audioEngine.createRenderEntity<netero::audio::signals::sinusoid>(0.01, 261.63, 0);
-        auto* noteMi = audioEngine.createRenderEntity<netero::audio::signals::sinusoid>(0.01, 329.63, 0);
-        auto* noteLa = audioEngine.createRenderEntity<netero::audio::signals::sinusoid>(0.01, 400, 0);
+        auto* noteDo = audioEngine.createRenderEntity<netero::audio::signals::sinusoid>(0.01F, 261.63F, 0.0F);
+        auto* noteMi = audioEngine.createRenderEntity<netero::audio::signals::sinusoid>(0.01F, 329.63F, 0.0F);
+        auto* noteLa = audioEngine.createRenderEntity<netero::audio::signals::sinusoid>(0.01F, 400.0F, 0.0F);
 
         noteDo->play();
 

--- a/tests/test_os.cpp
+++ b/tests/test_os.cpp
@@ -3,6 +3,7 @@
  * see LICENSE.txt
  */
 
+#include <cassert>
 #include <iostream>
 #include <netero/os.hpp>
 

--- a/tests/test_os.cpp
+++ b/tests/test_os.cpp
@@ -1,0 +1,21 @@
+/**
+ * Netero sources under BSD-3-Clause
+ * see LICENSE.txt
+ */
+
+#include <iostream>
+#include <netero/os.hpp>
+
+int	main() {
+	netero::os::acquireSystemResources();
+	assert(netero::os::getSystemResourcesLocks() == 1);
+	netero::os::releaseSystemResources();
+	assert(netero::os::getSystemResourcesLocks() == 0);
+
+	std::cout << netero::os::getSessionUsername() << std::endl;
+	std::cout << netero::os::getUserHomeDirectoryPath() << std::endl;
+	std::cout << netero::os::getUserAppDataRoamingPath() << std::endl;
+
+	return 0;
+}
+


### PR DESCRIPTION
**enhancement**

Add an os namespace in the core module that adds the following function:
 - getSessionUser -> Return the logon user name`
 - getUserHomeDirectoryPath -> pretty explicit...
 - getUserAppDataRoamingPath -> path to directory for application config files and data
 - acquireSystemRessources -> acquire COM library on windows, just increment a reference lock on other OS
 - releaseSystemRessources -> release previously acquired COM lib if refference count = 0 and if netero hold the COM Library initalization, just decrement refference count on other OS
 - getSystemResourcesLocks ->return how man time the refference count has been acquired.
 - isSystemLibraryHolder -> return true if netero hold the COM library initialization.

Netero will not call coUninitialize if it is not "holding the initialization" this will fix a bug while Netero is used besides other libraries like JUCE.